### PR TITLE
Add memoization support for all files in the file loader machinery

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 This library provides i18n functionality for Python 3 out of the box. The usage is mostly based on Rails i18n library.
 
+# Fork differences from the upstream repo
+
+- Enable memoization of the translation files
+
 ## Installation
 
 Just run
@@ -38,6 +42,14 @@ in `/path/to/translations` folder, you simply need to add the folder to the tran
 Please note that YAML format is used as default file format if you have `yaml` module installed.
 If both `yaml` and `json` modules available and you want to use JSON to store translations, explicitly specify that: `i18n.set('file_format', 'json')`
 
+### Memoization
+
+Setting the configuration value `enable_memoization` in the settings dir will load the files from disk the first time they
+are loaded and then store their content in memory. On the next use the file content will be provided from memory and not
+loaded from disk, preventing disk access. While this can be useful in some contexts, keep in mind there is no current way of
+issuing a command to the reloader to re-read the files from disk, so if you are updating your translation file without restarting
+the interpreter do not use this option.
+ 
 ### Namespaces
 
 #### File namespaces

--- a/i18n/config.py
+++ b/i18n/config.py
@@ -24,7 +24,8 @@ settings = {
     'encoding': 'utf-8',
     'namespace_delimiter': '.',
     'plural_few': 5,
-    'skip_locale_root_data': False
+    'skip_locale_root_data': False,
+    'enable_memoization': False
 }
 
 def set(key, value):

--- a/i18n/loaders/loader.py
+++ b/i18n/loaders/loader.py
@@ -14,13 +14,23 @@ class Loader(object):
     """Base class to load resources"""
     def __init__(self):
         super(Loader, self).__init__()
+        self.memoization_dict = {}
 
-    def load_file(self, filename):
+    def _load_file_data(self, filename):
         try:
             with io.open(filename, 'r', encoding=config.get('encoding')) as f:
                 return f.read()
         except IOError as e:
             raise I18nFileLoadError("error loading file {0}: {1}".format(filename, e.strerror))
+
+    def load_file(self, filename):
+        enable_memoization = config.get('enable_memoization')
+        if enable_memoization:
+            if filename not in self.memoization_dict:
+                self.memoization_dict[filename] = self._load_file_data(filename)
+            return self.memoization_dict[filename]
+        else:
+            return self._load_file_data(filename)
 
     def parse_file(self, file_content):
         raise NotImplementedError("the method parse_file has not been implemented for class {0}".format(self.__class__.name__))

--- a/i18n/tests/loader_tests.py
+++ b/i18n/tests/loader_tests.py
@@ -5,9 +5,12 @@ from __future__ import unicode_literals
 import unittest
 import os
 import os.path
+import tempfile
 
+import i18n
 from i18n import resource_loader
 from i18n.resource_loader import I18nFileLoadError
+from i18n.translator import t
 from i18n import config
 from i18n.config import json_available, yaml_available
 from i18n import translations
@@ -70,6 +73,39 @@ class TestFileLoader(unittest.TestCase):
         data = resource_loader.load_resource(os.path.join(RESOURCE_FOLDER, "settings", "dummy_config.py"), "settings")
         self.assertIn("foo", data)
         self.assertEqual("bar", data["foo"])
+
+    @unittest.skipUnless(yaml_available, "yaml library not available")
+    def test_memoization_with_file(self):
+        '''This test creates a temporary file with the help of the
+        tempfile library and writes a simple key: value dictionary in it.
+        It will then use that file to load the translations and, after having
+        enabled memoization, try to access it, causing the file to be (hopefully)
+        memoized. It will then _remove_ the temporary file and try to access again,
+        asserting that an error is not raised, thus making sure the data is
+        actually loaded from memory and not from disk access.'''
+        memoization_file_name = 'memoize.en.yml'
+        # create the file and write the data in it
+        try:
+            d = tempfile.TemporaryDirectory()
+            tmp_dir_name = d.name
+        except AttributeError:
+            # we are running python2, use mkdtemp
+            tmp_dir_name = tempfile.mkdtemp()
+        fd = open('{}/{}'.format(tmp_dir_name, memoization_file_name), 'w')
+        fd.write('en:\n  key: value')
+        fd.close()
+        # create the loader and pass the file to it
+        resource_loader.init_yaml_loader()
+        resource_loader.load_translation_file(memoization_file_name, tmp_dir_name)
+        # try loading the value to make sure it's working
+        self.assertEqual(t('memoize.key'), 'value')
+        # now delete the file and directory
+        # we are running python2, delete manually
+        import shutil
+        shutil.rmtree(tmp_dir_name)
+        # test the translation again to make sure it's loaded from memory
+        self.assertEqual(t('memoize.key'), 'value')
+
 
     @unittest.skipUnless(json_available, "json library not available")
     def test_load_file_with_strange_encoding(self):


### PR DESCRIPTION
This change would add an `enable_memoization` option to the configuration file, set to false by default to preserve the original behaviour. Setting this option to `true` in the configuration would create a dictionary of files in the base loader class that stores the file content to avoid having to open-read-close the file at each request.

Let me know what you think, if this feature could be useful and if the patch looks good as i might as well have forgotten some side effect or implications.