### PR TITLE
#1 nested dict json support

### DIFF
--- a/i18n/tests/loader_tests.py
+++ b/i18n/tests/loader_tests.py
@@ -187,6 +187,54 @@ class TestFileLoader(unittest.TestCase):
         resource_loader.search_translation("foo")
         self.assertTrue(translations.has("foo"))
 
+    @unittest.skipUnless(json_available, "json library not available")
+    def test_search_translation_without_ns_nested_dict__two_levels_neting__default_locale(self):
+        resource_loader.init_json_loader()
+        config.set("file_format", "json")
+        config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
+        config.set("filename_format", "{locale}.{format}")
+        config.set('skip_locale_root_data', True)
+        config.set("locale", ["en", "pl"])
+        resource_loader.search_translation("COMMON.VERSION")
+        self.assertTrue(translations.has("COMMON.VERSION"))
+        self.assertEqual(translations.get("COMMON.VERSION"), "version")
+
+    @unittest.skipUnless(json_available, "json library not available")
+    def test_search_translation_without_ns_nested_dict__two_levels_neting__other_locale(self):
+        resource_loader.init_json_loader()
+        config.set("file_format", "json")
+        config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
+        config.set("filename_format", "{locale}.{format}")
+        config.set('skip_locale_root_data', True)
+        config.set("locale", ["en", "pl"])
+        resource_loader.search_translation("COMMON.VERSION", locale="pl")
+        self.assertTrue(translations.has("COMMON.VERSION", locale="pl"))
+        self.assertEqual(translations.get("COMMON.VERSION", locale="pl"), "wersja")
+
+    @unittest.skipUnless(json_available, "json library not available")
+    def test_search_translation_without_ns_nested_dict__default_locale(self):
+        resource_loader.init_json_loader()
+        config.set("file_format", "json")
+        config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
+        config.set("filename_format", "{locale}.{format}")
+        config.set('skip_locale_root_data', True)
+        config.set("locale", "en")
+        resource_loader.search_translation("TOP_MENU.TOP_BAR.LOGS")
+        self.assertTrue(translations.has("TOP_MENU.TOP_BAR.LOGS"))
+        self.assertEqual(translations.get("TOP_MENU.TOP_BAR.LOGS"), "Logs")
+
+    @unittest.skipUnless(json_available, "json library not available")
+    def test_search_translation_without_ns_nested_dict__other_locale(self):
+        resource_loader.init_json_loader()
+        config.set("file_format", "json")
+        config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
+        config.set("filename_format", "{locale}.{format}")
+        config.set('skip_locale_root_data', True)
+        config.set("locale", "en")
+        resource_loader.search_translation("TOP_MENU.TOP_BAR.LOGS", locale="pl")
+        self.assertTrue(translations.has("TOP_MENU.TOP_BAR.LOGS", locale="pl"))
+        self.assertEqual(translations.get("TOP_MENU.TOP_BAR.LOGS", locale="pl"), "Logi")
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestFileLoader)
 unittest.TextTestRunner(verbosity=2).run(suite)

--- a/i18n/tests/loader_tests.py
+++ b/i18n/tests/loader_tests.py
@@ -15,6 +15,14 @@ from i18n import config
 from i18n.config import json_available, yaml_available
 from i18n import translations
 
+try:
+    reload  # Python 2.7
+except NameError:
+    try:
+        from importlib import reload  # Python 3.4+
+    except ImportError:
+        from imp import reload  # Python 3.0 - 3.3
+
 
 RESOURCE_FOLDER = os.path.join(os.path.dirname(__file__), "resources")
 
@@ -23,6 +31,7 @@ class TestFileLoader(unittest.TestCase):
     def setUp(self):
         resource_loader.loaders = {}
         translations.container = {}
+        reload(config)
         config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations")])
         config.set("filename_format", "{namespace}.{locale}.{format}")
         config.set("encoding", "utf-8")

--- a/i18n/tests/resources/translations/nested_dict_json/en.json
+++ b/i18n/tests/resources/translations/nested_dict_json/en.json
@@ -1,0 +1,27 @@
+{
+  "TOP_MENU": {
+    "TOP_BAR": {
+      "LOGS": "Logs",
+      "LOGS_ITEMS": {
+        "MAIN": "Main process",
+        "ERROR": "Errors",
+        "CUSTOM": "Custom Logs"
+      },
+      "NOTIFICATIONS": "Notifications",
+      "CONFIG": "Config",
+      "LICENSE": "License"
+    }
+  },
+  "COMMON": {
+    "HOME": "Home",
+    "START": "Start",
+    "STOP": "Stop",
+    "REFRESH": "Refresh",
+    "LOAD_FILE": "Load file",
+    "DELETE_FILE": "Delete file",
+    "EXECUTE": "Execute",
+    "DELETE": "Delete",
+    "VERSION": "version",
+    "SUBMIT": "Submit"
+  }
+}

--- a/i18n/tests/resources/translations/nested_dict_json/pl.json
+++ b/i18n/tests/resources/translations/nested_dict_json/pl.json
@@ -1,0 +1,27 @@
+{
+  "TOP_MENU": {
+    "TOP_BAR": {
+       "LOGS": "Logi",
+         "LOGS_ITEMS": {
+           "MAIN": "Główny proces",
+           "ERROR": "Błędy",
+           "CUSTOM": "Logi dodatkowe"
+            },
+       "NOTIFICATIONS": "Powiadomienia",
+       "CONFIG": "Konfiguracja",
+       "LICENSE": "Licencja"
+    }
+  },
+   "COMMON": {
+    "HOME": "Początek",
+    "START": "Start",
+    "STOP": "Stop",
+    "REFRESH": "Odśwież",
+    "LOAD_FILE": "Załaduj",
+    "DELETE_FILE": "Usuń",
+    "EXECUTE": "Wykonaj",
+    "DELETE": "Usuń",
+    "VERSION": "wersja",
+    "SUBMIT": "Wyślij"
+  }
+}

--- a/i18n/tests/translation_tests.py
+++ b/i18n/tests/translation_tests.py
@@ -113,3 +113,21 @@ class TestTranslationFormat(unittest.TestCase):
         resource_loader.init_loaders()
         self.assertEqual(t('foo'), 'Lorry')
         config.set('skip_locale_root_data', False)
+
+    def test_skip_locale_root_data_nested_json_dict__default_locale(self):
+        config.set("file_format", "json")
+        config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
+        config.set("filename_format", "{locale}.{format}")
+        config.set('skip_locale_root_data', True)
+        config.set("locale", "en")
+        resource_loader.init_json_loader()
+        self.assertEqual(t('COMMON.START'), 'Start')
+
+    def test_skip_locale_root_data_nested_json_dict__other_locale(self):
+        config.set("file_format", "json")
+        config.set("load_path", [os.path.join(RESOURCE_FOLDER, "translations", "nested_dict_json")])
+        config.set("filename_format", "{locale}.{format}")
+        config.set('skip_locale_root_data', True)
+        config.set("locale", "en")
+        resource_loader.init_json_loader()
+        self.assertEqual(t('COMMON.EXECUTE', locale="pl"), 'Wykonaj')

--- a/i18n/tests/translation_tests.py
+++ b/i18n/tests/translation_tests.py
@@ -11,6 +11,14 @@ from i18n.translator import t
 from i18n import translations
 from i18n import config
 
+try:
+    reload  # Python 2.7
+except NameError:
+    try:
+        from importlib import reload  # Python 3.4+
+    except ImportError:
+        from imp import reload  # Python 3.0 - 3.3
+
 RESOURCE_FOLDER = os.path.dirname(__file__) + os.sep + 'resources' + os.sep
 
 
@@ -18,6 +26,7 @@ class TestTranslationFormat(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         resource_loader.init_loaders()
+        reload(config)
         config.set('load_path', [os.path.join(RESOURCE_FOLDER, 'translations')])
         translations.add('foo.hi', 'Hello %{name} !')
         translations.add('foo.hello', 'Salut %{name} !', locale='fr')


### PR DESCRIPTION
This PR adds UT for JSON translation files with nested dictionaries. Originally it's purpose was to add support for nested dictionaries which turned out to be supported out of the box so only UT are added to provide examples on how to properly configure the module.

Additionally UT are fixed - config instance was being modified by each test. Now config is reloaded for each UT. 